### PR TITLE
Fix player deceleration using frame time

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -66,8 +66,8 @@ func handle_normal_movement(delta: float) -> void:
 		velocity.y = jump_velocity
 
 	# Get input direction for left/right movement
-	var direction := Input.get_axis("move_left", "move_right")
-	if direction != 0:
-		velocity.x = direction * speed
-	else:
-		velocity.x = move_toward(velocity.x, 0, speed)
+        var direction := Input.get_axis("move_left", "move_right")
+        if direction != 0:
+                velocity.x = direction * speed
+        else:
+                velocity.x = move_toward(velocity.x, 0, speed * delta)


### PR DESCRIPTION
## Summary
- decelerate the player smoothly by scaling move_toward step with delta

## Testing
- `godot3 --headless --check-only` *(fails: Can't open project: config version 5 is from newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_688e583cf3f4832b935f420b4d74ea1f