### PR TITLE
Add weapon script with multiple player attacks

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -55,6 +55,19 @@ dash={
 ]
 }
 
+quick_attack={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":74,"key_label":0,"unicode":106,"location":0,"echo":false,"script":null)]
+}
+heavy_attack={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":75,"key_label":0,"unicode":107,"location":0,"echo":false,"script":null)]
+}
+special_attack={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":76,"key_label":0,"unicode":108,"location":0,"echo":false,"script":null)]
+}
+
 [layer_names]
 
 2d_physics/layer_1="player"

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -1,5 +1,7 @@
 extends CharacterBody2D
 
+const Weapon := preload("res://scripts/weapon.gd")
+
 @export var speed: float = 300.0
 @export var jump_velocity: float = -400.0
 @export var dash_speed: float = 900.0
@@ -12,23 +14,29 @@ var is_dashing: bool = false
 var dash_timer: float = 0.0
 var dash_cooldown_timer: float = 0.0
 var dash_direction: Vector2 = Vector2.ZERO
+var weapon: Node
+
+func _ready() -> void:
+	weapon = Weapon.new()
+	add_child(weapon)
 
 func _physics_process(delta: float) -> void:
 	# Update dash cooldown timer
 	if dash_cooldown_timer > 0:
 		dash_cooldown_timer -= delta
-	
+
 	# Handle dash input
 	if Input.is_action_just_pressed("dash") and dash_cooldown_timer <= 0 and not is_dashing:
 		start_dash()
-	
+
 	# Handle dash logic
 	if is_dashing:
 		handle_dash(delta)
 	else:
 		handle_normal_movement(delta)
-	
+
 	move_and_slide()
+	handle_attack_input()
 
 func start_dash() -> void:
 	# Get dash direction from input or use facing direction
@@ -71,3 +79,11 @@ func handle_normal_movement(delta: float) -> void:
 		velocity.x = direction * speed
 	else:
 		velocity.x = move_toward(velocity.x, 0, speed)
+
+func handle_attack_input() -> void:
+	if Input.is_action_just_pressed("quick_attack"):
+		weapon.quick_attack()
+	elif Input.is_action_just_pressed("heavy_attack"):
+		weapon.heavy_attack()
+	elif Input.is_action_just_pressed("special_attack"):
+		weapon.special_attack()

--- a/scripts/weapon.gd
+++ b/scripts/weapon.gd
@@ -1,0 +1,36 @@
+extends Node
+
+@export var quick_damage: int = 10
+@export var heavy_damage: int = 25
+@export var special_damage: int = 50
+
+@export var quick_cooldown: float = 0.3
+@export var heavy_cooldown: float = 1.0
+@export var special_cooldown: float = 5.0
+
+var quick_timer: float = 0.0
+var heavy_timer: float = 0.0
+var special_timer: float = 0.0
+
+func _process(delta: float) -> void:
+	if quick_timer > 0:
+		quick_timer -= delta
+	if heavy_timer > 0:
+		heavy_timer -= delta
+	if special_timer > 0:
+		special_timer -= delta
+
+func quick_attack() -> void:
+	if quick_timer <= 0:
+		quick_timer = quick_cooldown
+		print("Quick attack dealing %d damage" % quick_damage)
+
+func heavy_attack() -> void:
+	if heavy_timer <= 0:
+		heavy_timer = heavy_cooldown
+		print("Heavy attack dealing %d damage" % heavy_damage)
+
+func special_attack() -> void:
+	if special_timer <= 0:
+		special_timer = special_cooldown
+		print("Special attack dealing %d damage" % special_damage)

--- a/scripts/weapon.gd.uid
+++ b/scripts/weapon.gd.uid
@@ -1,0 +1,1 @@
+uid://zcxggxeyeh6r


### PR DESCRIPTION
## Summary
- add Weapon script supporting quick, heavy, and special attacks
- hook player into weapon and new input actions
- define quick, heavy, and special attack inputs in project settings

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_688e58a940b0832b95e6d11a08390bf5